### PR TITLE
Windows Support: Enable cross-platform builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,7 @@ install:
 
 build_script:
     - esy-bash ./esy-configure --prefix C:/ocaml-bits
-    - esy-bash make world.opt
-    - esy-bash make flexlink.opt
-    - esy-bash make install
+    - esy-bash ./esy-build
     - esy-bash cp /cygdrive/c/ocaml-bits/bin/flexlink.exe /usr/local/bin/flexlink.exe
     - echo print_endline "Hello from OCaml";; > C:/ocaml-bits/test.ml
     - esy-bash which flexlink

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ platform:
     - x86
 
 install:
-    - npm install esy-bash
+    - npm install -g esy-bash
 
 build_script:
     - esy-bash ./esy-configure --prefix C:/ocaml-bits

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
 
 build_script:
     - esy-bash ./esy-configure --prefix C:/ocaml-bits
-    - esy-bash make world.opts
+    - esy-bash make world
     - esy-bash make install
 
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,5 +9,8 @@ build_script:
     - esy-bash ./esy-configure --prefix C:/ocaml-bits
     - esy-bash make world.opt
     - esy-bash make install
+    - echo print_endline "Hello from OCaml";; > C:/test.ml
+    - esy-bash /cygdrive/c/ocaml-bits/bin/ocamlopt.exe /cygdrive/c/test.ml -o test.native
+    - C:/test.native.exe
 
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
 
 build_script:
     - esy-bash ./esy-configure --prefix C:/ocaml-bits
-    - esy-bash make world
+    - esy-bash make world.opt
     - esy-bash make install
 
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,44 +1,13 @@
-#**************************************************************************
-#*                                                                        *
-#*                                 OCaml                                  *
-#*                                                                        *
-#*                         Christophe Troestler                           *
-#*                                                                        *
-#*   Copyright 2015 Christophe Troestler                                  *
-#*                                                                        *
-#*   All rights reserved.  This file is distributed under the terms of    *
-#*   the GNU Lesser General Public License version 2.1, with the          *
-#*   special exception on linking described in the file LICENSE.          *
-#*                                                                        *
-#**************************************************************************
-
-# Compile the 64 bits version
 platform:
-  - x64
-
-image: Visual Studio 2015
-
-# Do a shallow clone of the repo to speed up the build
-clone_depth: 1
-
-environment:
-  global:
-    CYG_ROOT: C:/cygwin64
-    CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
-    CYG_CACHE: C:/cygwin64/var/cache/setup
-    FLEXDLL_VERSION: 0.37
-    OCAMLRUNPARAM: v=0,b
-
-cache:
-  - C:\cygwin64\var\cache\setup
+    - x64
+    - x86
 
 install:
-# This is a hangover from monitoring effects of MPR#7452
-  - wmic cpu get name
-  - call "%APPVEYOR_BUILD_FOLDER%\appveyor_build.cmd" install
+    - npm install esy-bash
 
 build_script:
-  - call "%APPVEYOR_BUILD_FOLDER%\appveyor_build.cmd" build
+    - esy-bash ./esy-configure --prefix C:/ocaml-bits
+    - esy-bash make world.opts
+    - esy-bash make install
 
-test_script:
-  - call "%APPVEYOR_BUILD_FOLDER%\appveyor_build.cmd" test
+test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,9 @@ build_script:
     - esy-bash make world.opt
     - esy-bash make flexlink.opt
     - esy-bash make install
+    - esy-bash cp /cygdrive/c/ocaml-bits/bin/flexlink.exe /usr/local/bin/flexlink.exe
     - echo print_endline "Hello from OCaml";; > C:/ocaml-bits/test.ml
+    - esy-bash which flexlink
     - esy-bash /cygdrive/c/ocaml-bits/bin/ocamlopt.exe -o C:/ocaml-bits/test-output C:/ocaml-bits/test.ml
     - C:/ocaml-bits/test-output.exe
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ install:
 build_script:
     - esy-bash ./esy-configure --prefix C:/ocaml-bits
     - esy-bash make world.opt
+    - esy-bash make flexlink.opt
     - esy-bash make install
     - echo print_endline "Hello from OCaml";; > C:/ocaml-bits/test.ml
     - esy-bash /cygdrive/c/ocaml-bits/bin/ocamlopt.exe -o C:/ocaml-bits/test-output C:/ocaml-bits/test.ml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,8 @@ build_script:
     - esy-bash ./esy-configure --prefix C:/ocaml-bits
     - esy-bash make world.opt
     - esy-bash make install
-    - echo print_endline "Hello from OCaml";; > C:/test.ml
-    - esy-bash /cygdrive/c/ocaml-bits/bin/ocamlopt.exe /cygdrive/c/test.ml -o test.native
-    - C:/test.native.exe
+    - echo print_endline "Hello from OCaml";; > C:/ocaml-bits/test.ml
+    - esy-bash /cygdrive/c/ocaml-bits/bin/ocamlopt.exe -o C:/ocaml-bits/test-output C:/ocaml-bits/test.ml
+    - C:/ocaml-bits/test-output.exe
 
 test: off

--- a/configure-windows
+++ b/configure-windows
@@ -19,8 +19,8 @@ done
 echo "[configure-windows] Prefix path: $prefix"
 
 echo "[configure-windows] Copying architecture headers."
-cp config/m-nt.h config/m.h
-cp config/s-nt.h config/s.h
+cp config/m-nt.h byterun/caml/m.h
+cp config/s-nt.h byterun/caml/s.h
 
 # TODO: Differentiate based on architecture - use 'Makefile.mingw' for 32-bit environments
 echo "[configure-windows] Bringing over mingw64 Makefile."

--- a/configure-windows
+++ b/configure-windows
@@ -28,3 +28,7 @@ cp config/Makefile.mingw64 config/Makefile
 
 echo "[configure-windows] Replace prefix path with: $prefix."
 sed -i "s#PREFIX=C:/ocamlmgw64#PREFIX=$prefix#g" config/Makefile
+
+echo "[configure-windows] Setting up flexdll"
+git clone https://github.com/alainfrisch/flexdll.git
+make flexdll

--- a/configure-windows
+++ b/configure-windows
@@ -1,0 +1,30 @@
+#! /bin/sh
+
+# configure-windows
+#
+# Creates a native Windows MingW build, based on:
+# https://github.com/ocaml/ocaml/blob/trunk/README.win32.adoc
+
+
+export prefix=C:/ocamlmgw64
+while : ; do
+    case "$1" in
+        "") break;;
+        -prefix|--prefix)
+            prefix=$2; shift;;
+    esac
+    shift
+done
+
+echo "[configure-windows] Prefix path: $prefix"
+
+echo "[configure-windows] Copying architecture headers."
+cp config/m-nt.h config/m.h
+cp config/s-nt.h config/s.h
+
+# TODO: Differentiate based on architecture - use 'Makefile.mingw' for 32-bit environments
+echo "[configure-windows] Bringing over mingw64 Makefile."
+cp config/Makefile.mingw64 config/Makefile
+
+echo "[configure-windows] Replace prefix path with: $prefix."
+sed -i "s#PREFIX=C:/ocamlmgw64#PREFIX=$prefix#g" config/Makefile

--- a/esy-build
+++ b/esy-build
@@ -1,0 +1,21 @@
+#! /bin/sh
+
+# esy-build
+#
+# Wrapper to execute appropriate build strategy, based on platform
+
+case "$(uname -s)" in
+    CYGWIN*|MINGW32*|MSYS*)
+        echo "[esy-build] Detected windows environment..."
+        make -j1 world.opt
+        make flexlink.opt
+        ;;
+    *)
+        echo "[esy-build] Detected OSX / Linux environment"
+        make -j world.opt
+        ;;
+esac
+
+# Common build steps
+make install
+make clean

--- a/esy-configure
+++ b/esy-configure
@@ -2,8 +2,8 @@
 
 # esy-configure
 #
-# Wrapper to delegate to the appropriate `configure` strategy,
-# based on the active platform.
+# Wrapper to delegate to configuration to the 
+# appropriate `configure` strategy based on the active platform.
 #
 # Today, OCaml has separate build strategies:
 # - Linux, OSX, Cygwin (gcc) - https://github.com/ocaml/ocaml/blob/trunk/INSTALL.adoc

--- a/esy-configure
+++ b/esy-configure
@@ -1,0 +1,25 @@
+#! /bin/sh
+
+# esy-configure
+#
+# Wrapper to delegate to the appropriate `configure` strategy,
+# based on the active platform.
+#
+# Today, OCaml has separate build strategies:
+# - Linux, OSX, Cygwin (gcc) - https://github.com/ocaml/ocaml/blob/trunk/INSTALL.adoc
+# - Windows, Cygin (mingw) - https://github.com/ocaml/ocaml/blob/trunk/README.win32.adoc
+#
+# We want `esy` to work cross-platform, so this is a shim script that will delegate to the
+# appropriate script depending on the platform. We assume that if the platform is `CYGWIN`
+# that the `mingw` (native executable) strategy is desired.
+
+case "$(uname -s)" in
+    CYGWIN*|MINGW32*|MSYS*)
+        echo "[esy-configure] Detected windows environment..."
+        ./configure-windows "$@"
+        ;;
+    *)
+        echo "[esy-configure] Detected OSX / Linux environment"
+        ./configure "$@"
+        ;;
+esac

--- a/package.json
+++ b/package.json
@@ -8,13 +8,7 @@
   "esy": {
     "build": [
       "./esy-configure -no-cfi -prefix $cur__install",
-      [
-        "sh",
-        "-c",
-        "[[ `uname -s` == CYGWIN* ]] && make -j1 world.opt || make -j world.opt"
-      ],
-      "make install",
-      "make clean"
+      "./esy-build"
     ],
     "buildsInSource": true,
     "exportedEnv": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "esy": {
     "build": [
-      "./configure -no-cfi -prefix $cur__install",
+      "./esy-configure -no-cfi -prefix $cur__install",
       [
         "sh",
         "-c",


### PR DESCRIPTION
### Issue

The current `build` strategy specified in the `package.json` is only for Linux and OSX (and native Cygwin) builds. Unfortunately, the OCaml compiler essentially has a forked set of build steps for native windows - you can find details here: https://github.com/ocaml/ocaml/blob/trunk/README.win32.adoc

This is also reflected in the steps used to build the compiler in the forked Windows OPAM repro:
- https://github.com/fdopen/opam-repository-mingw/blob/master/compilers/4.06.1/4.06.1%2Bmingw64/4.06.1%2Bmingw64.comp

As well as in the  appveyor build scripts used to validate the compiler:
https://github.com/ocaml/ocaml/blob/trunk/tools/ci/appveyor/appveyor_build.sh

The forked OPAM repo can declare its own set of build steps, but since we use the same package across platforms, we don't have that luxury (unless there is an affordance for specifying per-platform build steps).

In addition, I want to make sure our strategy can be easily merged across new compiler versions - therefore, I didn't want to modify `./configure`, because those merge conflicts could quickly become intractable.

### Proposed Fix

This change factors our top-level scripts defined in our `package.json` as follows:
- `./esy-configure` - on OSX and Linux, do the `./configure` stuff. On Windows, do the manual steps called out in the OCaml Windows build doc.
- `./esy-build` - on all platforms, we do `make world.opt`, `make install`, and `make clean`, however on Windows, we also need a step to build flexdll/flexlink.

This also sets up an `appveyor` build strategy such that we build the entire compiler using [esy-bash](https://github.com/bryphe/esy-bash), and validate that `ocamlopt.exe` provides a valid Windows executable. An example run is here: https://ci.appveyor.com/project/bryphe/ocaml/build/1.0.12/job/86fpo62sehh55b13

I opted to set up a new appveyor build strategy that runs the top-level scripts, so it would mirror the strategy that would be used when we actually build this package on windows machines.

One hairy part at the moment is that `ocamlopt.exe` needs to be able to find `flexlink.exe` (and other things like `mingw` compilers) in the `PATH` - so I copy it over in the build step. We may need to add something to our sandbox or augment the PATH to include the flexlink path.
