### PR TITLE
Ensure scripts don't continue to execute when a command fails

### DIFF
--- a/configure-windows
+++ b/configure-windows
@@ -31,3 +31,4 @@ sed -i "s#PREFIX=C:/ocamlmgw64#PREFIX=$prefix#g" config/Makefile
 
 echo "[configure-windows] Setting up flexdll"
 git clone https://github.com/alainfrisch/flexdll.git
+make flexdll

--- a/configure-windows
+++ b/configure-windows
@@ -31,4 +31,3 @@ sed -i "s#PREFIX=C:/ocamlmgw64#PREFIX=$prefix#g" config/Makefile
 
 echo "[configure-windows] Setting up flexdll"
 git clone https://github.com/alainfrisch/flexdll.git
-make flexdll

--- a/esy-build
+++ b/esy-build
@@ -11,7 +11,6 @@ set -o pipefail
 case "$(uname -s)" in
     CYGWIN*|MINGW32*|MSYS*)
         echo "[esy-build] Detected windows environment..."
-        make flexdll
         make -j1 world.opt
         make flexlink.opt
         ;;

--- a/esy-build
+++ b/esy-build
@@ -4,9 +4,14 @@
 #
 # Wrapper to execute appropriate build strategy, based on platform
 
+set -u
+set -e
+set -o pipefail
+
 case "$(uname -s)" in
     CYGWIN*|MINGW32*|MSYS*)
         echo "[esy-build] Detected windows environment..."
+        make flexdll
         make -j1 world.opt
         make flexlink.opt
         ;;

--- a/esy-configure
+++ b/esy-configure
@@ -13,6 +13,10 @@
 # appropriate script depending on the platform. We assume that if the platform is `CYGWIN`
 # that the `mingw` (native executable) strategy is desired.
 
+set -u
+set -e
+set -o pipefail
+
 case "$(uname -s)" in
     CYGWIN*|MINGW32*|MSYS*)
         echo "[esy-configure] Detected windows environment..."


### PR DESCRIPTION
Per our Discord discussion - add the following to each shell script:
```
set -u
set -e
set -o pipefail
```
So that the scripts actually fail and don't continue to execute commands. Thanks for catching this @andreypopp !