### PR TITLE
Windows Support: Update environment variables for windows-specific paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,15 +13,15 @@
     "buildsInSource": true,
     "exportedEnv": {
       "OCAMLLIB": {
-        "val": "#{ocaml.lib / 'ocaml'}",
+        "val": "#{os == 'windows' ? ocaml.lib : (ocaml.lib / 'ocaml')}",
         "scope": "global"
       },
       "CAML_LD_LIBRARY_PATH": {
-        "val": "#{ocaml.lib / 'ocaml' / 'stublibs' : ocaml.lib / 'ocaml' : $CAML_LD_LIBRARY_PATH}",
+        "val": "#{os == 'windows' ? (ocaml.lib : ocaml.lib / 'stublibs' : $CAML_LD_LIBRARY_PATH) : (ocaml.lib / 'ocaml' / 'stublibs' : ocaml.lib / 'ocaml' : $CAML_LD_LIBRARY_PATH)}",
         "scope": "global"
       },
       "OCAML_TOPLEVEL_PATH": {
-        "val": "#{ocaml.lib / 'ocaml'}",
+        "val": "#{os == 'windows' ? ocaml.lib : (ocaml.lib / 'ocaml')}",
         "scope": "global"
       }
     }


### PR DESCRIPTION
__Issue:__ On Windows, the paths for the standard library are slightly different - there's an extra `ocaml` on the Mac builds.

For example:
- __Windows__ `stublibs`: `.esy\3_\i\ocaml-4.6.4-fd65cd36\lib\stublibs`
- __OSX/Linux__ `stublibs`: `.esy/3_/i/ocaml-4.6.4-fd65cd36/lib/ocaml/stublibs`

Note that extra `ocaml` in the path.

On Windows, this manifests as an `Unbound module Pervasives` when trying to invoke the `ocaml` compiler via the installed path. This is because the stdlib and the `ld.conf` file used for locating it isn't available with the out-of-box paths. This happens as soon as `esy` tries to build a subsequent project after building the `ocaml` compiler.

This leverages @andreypopp 's fix in esy/esy#226 to allow for os specific expressions.

@andreypopp - I tested this on both Windows and OSX by running `esy build-plan` and I saw expected results for `CAML_LD_LIBRARY_PATH`, `OCAMLLIB`, and `OCAML_TOPLEVEL_PATH` (Windows does not have the `ocaml` in the path, but OSX does). Let me know if there is some more testing I can do, though.