### PR TITLE
Windows: Use forked flexdll with our patch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "flexdll"]
-    path = flexdll
-    url = https://github.com/esy-ocaml/flexdll.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "flexdll"]
     path = flexdll
-    url = https://github.com/alainfrisch/flexdll.git
+    url = https://github.com/esy-ocaml/flexdll.git

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,8 @@ platform:
     - x86
 
 install:
-    - npm install -g esy-bash
+    - npm install -g esy@0.2.11
+    - appveyor-retry esy install
 
 build_script:
     - esy-bash ./esy-configure --prefix C:/ocaml-bits

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,7 @@ platform:
     - x86
 
 install:
-    - npm install -g esy@0.2.11
-    - appveyor-retry esy install
+    - npm install -g esy-bash
 
 build_script:
     - esy-bash ./esy-configure --prefix C:/ocaml-bits

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,7 @@ install:
 build_script:
     - esy-bash ./esy-configure --prefix C:/ocaml-bits
     - esy-bash ./esy-build
-    - esy-bash cp /cygdrive/c/ocaml-bits/bin/flexlink.exe /usr/local/bin/flexlink.exe
     - echo print_endline "Hello from OCaml";; > C:/ocaml-bits/test.ml
-    - esy-bash which flexlink
     - esy-bash /cygdrive/c/ocaml-bits/bin/ocamlopt.exe -o C:/ocaml-bits/test-output C:/ocaml-bits/test.ml
     - C:/ocaml-bits/test-output.exe
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ install:
 build_script:
     - esy-bash ./esy-configure --prefix C:/ocaml-bits
     - esy-bash ./esy-build
+    - esy-bash cp /cygdrive/c/ocaml-bits/bin/flexlink.exe /usr/local/bin/flexlink.exe
     - echo print_endline "Hello from OCaml";; > C:/ocaml-bits/test.ml
     - esy-bash /cygdrive/c/ocaml-bits/bin/ocamlopt.exe -o C:/ocaml-bits/test-output C:/ocaml-bits/test.ml
     - C:/ocaml-bits/test-output.exe

--- a/clone-flexdll
+++ b/clone-flexdll
@@ -4,14 +4,13 @@
 #
 # Brings in flexdll, if necessary
 
-if [ -d "flexdll"]; then
+if [ -d "flexdll" ]; then
+    echo "[Flexdll] Already present, no need to clone."
+else
     echo "[Flexdll] Cloning..."
     git clone https://github.com/esy-ocaml/flexdll.git
     cd flexdll
     git checkout 92d4c9e
     cd ..
     echo "[Flexdll] Clone successful!"
-else
-    echo "[Flexdll] Already present, no need to clone."
-endif
-
+fi

--- a/clone-flexdll
+++ b/clone-flexdll
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+# clone-flexdll
+#
+# Brings in flexdll, if necessary
+
+echo "[Flexdll] Cloning..."
+git clone https://github.com/esy-ocaml/flexdll.git
+cd flexdll
+git checkout 92d4c9e
+cd ..
+echo ["Flexdll] Clone successful!"

--- a/clone-flexdll
+++ b/clone-flexdll
@@ -4,9 +4,14 @@
 #
 # Brings in flexdll, if necessary
 
-echo "[Flexdll] Cloning..."
-git clone https://github.com/esy-ocaml/flexdll.git
-cd flexdll
-git checkout 92d4c9e
-cd ..
-echo ["Flexdll] Clone successful!"
+if [ -d "flexdll"]; then
+    echo "[Flexdll] Cloning..."
+    git clone https://github.com/esy-ocaml/flexdll.git
+    cd flexdll
+    git checkout 92d4c9e
+    cd ..
+    echo "[Flexdll] Clone successful!"
+else
+    echo "[Flexdll] Already present, no need to clone."
+endif
+

--- a/configure-windows
+++ b/configure-windows
@@ -30,5 +30,5 @@ echo "[configure-windows] Replace prefix path with: $prefix."
 sed -i "s#PREFIX=C:/ocamlmgw64#PREFIX=$prefix#g" config/Makefile
 
 echo "[configure-windows] Setting up flexdll"
-git submodule update --init
+./clone-flexdll
 make flexdll

--- a/configure-windows
+++ b/configure-windows
@@ -30,5 +30,8 @@ echo "[configure-windows] Replace prefix path with: $prefix."
 sed -i "s#PREFIX=C:/ocamlmgw64#PREFIX=$prefix#g" config/Makefile
 
 echo "[configure-windows] Setting up flexdll"
-git clone https://github.com/alainfrisch/flexdll.git
+git clone https://github.com/esy-ocaml/flexdll.git
+cd flexdll
+git checkout 92d4c9e
+cd ..
 make flexdll

--- a/configure-windows
+++ b/configure-windows
@@ -30,8 +30,5 @@ echo "[configure-windows] Replace prefix path with: $prefix."
 sed -i "s#PREFIX=C:/ocamlmgw64#PREFIX=$prefix#g" config/Makefile
 
 echo "[configure-windows] Setting up flexdll"
-git clone https://github.com/esy-ocaml/flexdll.git
-cd flexdll
-git checkout 92d4c9e
-cd ..
+git submodule update --init
 make flexdll


### PR DESCRIPTION
When building esy on Windows, we hit alainfrisch/flexdll#67, with a proposed patch here at alainfrisch/flexdll#68. This brings in the patch for our build of ocaml so that we can bootstrap esy on Windows.