### PR TITLE
Ocaml 4.6.x: Pick up flexdll fix (lower command length limit)

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -1,0 +1,40 @@
+# Cross-platform build pipeline + NPM publish
+
+name: $(Build.SourceVersion)
+jobs:
+- job: Linux
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+  - script: sudo apt-get install -y libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libegl1-mesa-dev mesa-utils mesa-utils-extra ragel
+  - template: esy-build-steps.yml
+
+- job: MacOS
+  pool:
+    vmImage: 'macOS 10.13'
+  steps:
+  - script: brew update
+  - script: brew install libpng
+  - template: esy-build-steps.yml
+
+- job: Windows
+  pool:
+    vmImage: 'vs2017-win2016'
+  steps:
+  - template: esy-build-steps.yml
+
+- job: Release
+  displayName: Release
+  dependsOn:
+      - Linux
+      - MacOS
+      - Windows
+  condition: succeeded()
+  pool:
+     vmImage: ubuntu-16.04
+  steps:
+    - task: PublishBuildArtifacts@1
+      displayName: 'Release Package'
+      inputs:
+          PathtoPublish: '.'
+          ArtifictName: npm-package

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -1,0 +1,9 @@
+# Cross-platform set of build steps for building esy projects
+
+steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '8.9'
+  - script: npm install -g esy@0.3.4
+  - script: esy install
+  - script: esy build

--- a/.gitattributes
+++ b/.gitattributes
@@ -103,7 +103,11 @@ yacc/*.[ch]   ocaml-typo=long-line,very-long-line,unused-prop
 *.precheck text eol=lf
 *.runner text eol=lf
 
+clone-flexdll text eol=lf
 configure text eol=lf
+configure-windows text eol=lf
+esy-configure text eol=lf
+esy-build text eol=lf
 config/auto-aux/hasgot text eol=lf
 config/auto-aux/hasgot2 text eol=lf
 config/auto-aux/runtest text eol=lf

--- a/clone-flexdll
+++ b/clone-flexdll
@@ -10,7 +10,7 @@ else
     echo "[Flexdll] Cloning..."
     git clone https://github.com/esy-ocaml/flexdll.git
     cd flexdll
-    git checkout 50d1f29
+    git checkout a3b2fd4
     cd ..
     echo "[Flexdll] Clone successful!"
 fi

--- a/clone-flexdll
+++ b/clone-flexdll
@@ -10,7 +10,7 @@ else
     echo "[Flexdll] Cloning..."
     git clone https://github.com/esy-ocaml/flexdll.git
     cd flexdll
-    git checkout 2b320fa
+    git checkout 50d1f29
     cd ..
     echo "[Flexdll] Clone successful!"
 fi


### PR DESCRIPTION
This picks up https://github.com/esy-ocaml/flexdll/pull/5

Also - use Azure CI to build, so we can have some CI verification that the build is successful