### PR TITLE
workaround for gcc 10 on linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,17 +9,17 @@ jobs:
   parameters:
     host: macOS
     pool:
-      vmImage: 'macOS-10.13'
+      vmImage: 'macOS-latest'
 
 - template: .ci/build.yaml  # Template reference
   parameters:
     host: Linux
     pool:
-      vmImage: 'Ubuntu-16.04'
+      vmImage: 'ubuntu-latest'
 
 - template: .ci/build.yaml  # Template reference
   parameters:
     host: Windows
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-latest'
     sign: true  # Extra step on Windows only

--- a/esy-configure
+++ b/esy-configure
@@ -27,3 +27,17 @@ case "$(uname -s)" in
         ./configure "$@"
         ;;
 esac
+
+# fix related to -fcommon on GCC 10 on Linux
+if [ "$(uname)" == 'Linux' ]; then
+    VERSION_NEEDED_TO_PATCH="10"
+
+    CC_CONFIG=$(cat Makefile.config | grep 'CC=' | awk -F= '{ print $2 }')
+    CC=$(echo $CC_CONFIG | awk '{ print $1 }')
+    
+    MAJOR_VERSION=$($CC -dumpversion | awk -F. '{ print $1 }' )
+
+    if [ $MAJOR_VERSION -ge $VERSION_NEEDED_TO_PATCH ]; then
+        echo 'OC_CFLAGS:=$(OC_FLAGS) -fcommon' >> Makefile.config
+    fi
+fi

--- a/esy-configure
+++ b/esy-configure
@@ -32,9 +32,9 @@ esac
 if [ "$(uname)" == 'Linux' ]; then
     VERSION_NEEDED_TO_PATCH="10"
 
-    CC_CONFIG=$(cat Makefile.config | grep 'CC=' | awk -F= '{ print $2 }')
+    CC_CONFIG=$(cat Makefile.config | awk -F= '{ if ($1 == "CC") { print $2 } }')
     CC=$(echo $CC_CONFIG | awk '{ print $1 }')
-    
+
     MAJOR_VERSION=$($CC -dumpversion | awk -F. '{ print $1 }' )
 
     if [ $MAJOR_VERSION -ge $VERSION_NEEDED_TO_PATCH ]; then


### PR DESCRIPTION
## Problem
 by ocaml/ocaml#9180, on GCC 10 because of the default mode changed from being `-fcommon` to `-fno-common` we get some conflicts, to address that adding `-fcommon` should be enough as a workaround.

## Workaround

The idea here is that we just need to add `-fcommon` to `OC_CFLAGS` which is the internal field, so `-fcommon` will not be applied to packages, only to ocaml itself.

## Detection

Runs `$CC -dumpversion` on gcc and clang it is something like `10.1.0`, if the major version is bigger than `10` we apply the patch, so it will endup detecting clang as gcc, but on Linux that is safe, as clang by default still runs on `-fcommon` and if they switch it would also needs the patch
