### PR TITLE
Remove --disable-cfi

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "esy": {
     "build": [
-      "./esy-configure --disable-cfi --prefix $cur__install",
+      "./esy-configure --prefix $cur__install",
       "./esy-build"
     ],
     "buildsInSource": true,


### PR DESCRIPTION
I'm not sure why it was added but, it's probably related on the old build script before `4.07`.

## Why?

This is important as without `--disable-cfi` we get some basic locs for debugging native binaries using tools like `lldb` and `gdb`