### PR TITLE
Use latest version of flexdll

### DIFF
--- a/clone-flexdll
+++ b/clone-flexdll
@@ -8,6 +8,6 @@ if [ -d "flexdll" ] && [ -f "flexdll/flexdll.c" ]; then
     echo "[Flexdll] Already present, no need to clone."
 else
     echo "[Flexdll] Cloning..."
-    git clone https://github.com/alainfrisch/flexdll --branch 0.39
+    git clone https://github.com/ocaml/flexdll --branch 0.42
     echo "[Flexdll] Clone successful!"
 fi


### PR DESCRIPTION
I'm submitting this against 4.14.0+esy but it probably belongs in something like 4.14.0001+esy since there are no upstream ocaml changes.

This PR updates the version of flexdll to 0.42, which adds support for the `-l:` flag. This is needed for some libraries (like libbinaryen & grain) to statically link certain libraries (e.g. `-l:libpthread.a`).

Ref https://github.com/ocaml/ocaml/issues/11531#issuecomment-1346281091